### PR TITLE
Update to v1.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.lloyd26</groupId>
     <artifactId>TeleportNotify</artifactId>
-    <version>1.5</version>
+    <version>1.5.1</version>
     <packaging>jar</packaging>
 
     <name>Teleport Notify</name>

--- a/src/main/java/me/lloyd26/teleportnotify/commands/tp.java
+++ b/src/main/java/me/lloyd26/teleportnotify/commands/tp.java
@@ -27,7 +27,7 @@ public class tp implements CommandExecutor {
                         Player target = Bukkit.getPlayer(args[0]);
                         TeleportUtil teleportUtil = new TeleportUtil(player, player, target);
                         teleportUtil.setExecutorMessage(plugin.getConfig().getString("messages.commands.tp.1player.player").replace("%target%", target.getName()));
-                        teleportUtil.setTargetMessage(plugin.getConfig().getString("messages.commands.tp.1player.target").replace("%player%", player.getName()));
+                        teleportUtil.setReceivedMessage(plugin.getConfig().getString("messages.commands.tp.1player.target").replace("%player%", player.getName()));
                         teleportUtil.setStaffMessage(plugin.getConfig().getString("messages.commands.tp.1player.staff").replace("%player%", sender.getName()).replace("%target%", target.getName()));
                         teleportUtil.teleportPlayer();
                     } else if (args.length == 1 && Bukkit.getOnlinePlayers().contains(Bukkit.getPlayer(args[0]))) {
@@ -38,8 +38,8 @@ public class tp implements CommandExecutor {
                             Player target = Bukkit.getPlayer(args[1]);
                             TeleportUtil teleportUtil = new TeleportUtil(sender, playerToSend, target);
                             teleportUtil.setExecutorMessage(plugin.getConfig().getString("messages.commands.tp.2player.player").replace("%player1%", playerToSend.getName()).replace("%player2%", target.getName()));
-                            teleportUtil.setPlayerMessage(plugin.getConfig().getString("messages.commands.tp.2player.player1").replace("%player2%", target.getName()).replace("%player%", (sender instanceof ConsoleCommandSender ? Utils.getConsoleName() : sender.getName())));
-                            teleportUtil.setTargetMessage(plugin.getConfig().getString("messages.commands.tp.2player.player2").replace("%player1%", playerToSend.getName()).replace("%player%", (sender instanceof ConsoleCommandSender ? Utils.getConsoleName() : sender.getName())));
+                            teleportUtil.setSentMessage(plugin.getConfig().getString("messages.commands.tp.2player.player1").replace("%player2%", target.getName()).replace("%player%", (sender instanceof ConsoleCommandSender ? Utils.getConsoleName() : sender.getName())));
+                            teleportUtil.setReceivedMessage(plugin.getConfig().getString("messages.commands.tp.2player.player2").replace("%player1%", playerToSend.getName()).replace("%player%", (sender instanceof ConsoleCommandSender ? Utils.getConsoleName() : sender.getName())));
                             teleportUtil.setStaffMessage(plugin.getConfig().getString("messages.commands.tp.2player.staff").replace("%player%", (sender instanceof ConsoleCommandSender ? Utils.getConsoleName() : sender.getName())).replace("%player1%", playerToSend.getName()).replace("%player2%", target.getName()));
                             teleportUtil.teleportPlayer();
                         } else {
@@ -67,7 +67,7 @@ public class tp implements CommandExecutor {
                                 teleportUtil.setStaffMessage(plugin.getConfig().getString("messages.commands.tp.coords.self.staff").replace("%player%", sender.getName()));
                             } else {
                                 teleportUtil.setExecutorMessage(plugin.getConfig().getString("messages.commands.tp.coords.other.player").replace("%player%", Bukkit.getPlayer(args[0]).getName()));
-                                teleportUtil.setTargetMessage(plugin.getConfig().getString("messages.commands.tp.coords.other.target").replace("%player%", (sender instanceof ConsoleCommandSender ? Utils.getConsoleName() : sender.getName())));
+                                teleportUtil.setReceivedMessage(plugin.getConfig().getString("messages.commands.tp.coords.other.target").replace("%player%", (sender instanceof ConsoleCommandSender ? Utils.getConsoleName() : sender.getName())));
                                 teleportUtil.setStaffMessage(plugin.getConfig().getString("messages.commands.tp.coords.other.staff").replace("%player%", (sender instanceof ConsoleCommandSender ? Utils.getConsoleName() : sender.getName())).replace("%target%", Bukkit.getPlayer(args[0]).getName()));
                             }
                             if (args.length == 6) {

--- a/src/main/java/me/lloyd26/teleportnotify/commands/tp.java
+++ b/src/main/java/me/lloyd26/teleportnotify/commands/tp.java
@@ -50,7 +50,7 @@ public class tp implements CommandExecutor {
                     }
                 } else if (args.length == 3 || args.length == 5 || args.length == 4 || args.length == 6) {
                     TeleportUtil teleportUtil = new TeleportUtil(sender, args[0], args[1], args[2]);
-                    teleportUtil.setPlayerMessage(plugin.getConfig().getString("messages.commands.tp.coords.self.player").replace("%player%", sender.getName()));
+                    teleportUtil.setExecutorMessage(plugin.getConfig().getString("messages.commands.tp.coords.self.player").replace("%player%", sender.getName()));
                     teleportUtil.setStaffMessage(plugin.getConfig().getString("messages.commands.tp.coords.self.staff").replace("%player%", sender.getName()));
                     if (sender instanceof Player) teleportUtil.setPlayer((Player) sender);
                     if (args.length == 5) {
@@ -63,10 +63,10 @@ public class tp implements CommandExecutor {
                             teleportUtil.setY(args[2]);
                             teleportUtil.setZ(args[3]);
                             if (Bukkit.getPlayer(args[0]).getName().equals(sender.getName())) {
-                                teleportUtil.setPlayerMessage(plugin.getConfig().getString("messages.commands.tp.coords.self.player").replace("%player%", sender.getName()));
+                                teleportUtil.setExecutorMessage(plugin.getConfig().getString("messages.commands.tp.coords.self.player").replace("%player%", sender.getName()));
                                 teleportUtil.setStaffMessage(plugin.getConfig().getString("messages.commands.tp.coords.self.staff").replace("%player%", sender.getName()));
                             } else {
-                                teleportUtil.setPlayerMessage(plugin.getConfig().getString("messages.commands.tp.coords.other.player").replace("%player%", Bukkit.getPlayer(args[0]).getName()));
+                                teleportUtil.setExecutorMessage(plugin.getConfig().getString("messages.commands.tp.coords.other.player").replace("%player%", Bukkit.getPlayer(args[0]).getName()));
                                 teleportUtil.setTargetMessage(plugin.getConfig().getString("messages.commands.tp.coords.other.target").replace("%player%", (sender instanceof ConsoleCommandSender ? Utils.getConsoleName() : sender.getName())));
                                 teleportUtil.setStaffMessage(plugin.getConfig().getString("messages.commands.tp.coords.other.staff").replace("%player%", (sender instanceof ConsoleCommandSender ? Utils.getConsoleName() : sender.getName())).replace("%target%", Bukkit.getPlayer(args[0]).getName()));
                             }

--- a/src/main/java/me/lloyd26/teleportnotify/commands/tpall.java
+++ b/src/main/java/me/lloyd26/teleportnotify/commands/tpall.java
@@ -22,7 +22,7 @@ public class tpall implements CommandExecutor {
                 if (sender instanceof Player && args.length == 0) {
                     Player player = (Player) sender;
                     TeleportUtil teleportUtil = new TeleportUtil(sender, Bukkit.getOnlinePlayers(), player.getLocation());
-                    teleportUtil.setPlayerMessage(plugin.getConfig().getString("messages.commands.tpall.self.player"));
+                    teleportUtil.setExecutorMessage(plugin.getConfig().getString("messages.commands.tpall.self.player"));
                     teleportUtil.setTargetMessage(plugin.getConfig().getString("messages.commands.tpall.self.target").replace("%player%", player.getName()));
                     teleportUtil.setStaffMessage(plugin.getConfig().getString("messages.commands.tpall.self.staff").replace("%player%", player.getName()));
                     teleportUtil.teleportPlayer();

--- a/src/main/java/me/lloyd26/teleportnotify/commands/tpall.java
+++ b/src/main/java/me/lloyd26/teleportnotify/commands/tpall.java
@@ -23,7 +23,7 @@ public class tpall implements CommandExecutor {
                     Player player = (Player) sender;
                     TeleportUtil teleportUtil = new TeleportUtil(sender, Bukkit.getOnlinePlayers(), player.getLocation());
                     teleportUtil.setExecutorMessage(plugin.getConfig().getString("messages.commands.tpall.self.player"));
-                    teleportUtil.setTargetMessage(plugin.getConfig().getString("messages.commands.tpall.self.target").replace("%player%", player.getName()));
+                    teleportUtil.setReceivedMessage(plugin.getConfig().getString("messages.commands.tpall.self.target").replace("%player%", player.getName()));
                     teleportUtil.setStaffMessage(plugin.getConfig().getString("messages.commands.tpall.self.staff").replace("%player%", player.getName()));
                     teleportUtil.teleportPlayer();
                 } else if (args.length == 0) {
@@ -33,7 +33,7 @@ public class tpall implements CommandExecutor {
                         Player player = Bukkit.getPlayer(args[0]);
                         TeleportUtil teleportUtil = new TeleportUtil(sender, Bukkit.getOnlinePlayers(), player.getLocation());
                         teleportUtil.setExecutorMessage(plugin.getConfig().getString("messages.commands.tpall.other.player").replace("%target%", player.getName()));
-                        teleportUtil.setTargetMessage(plugin.getConfig().getString("messages.commands.tpall.other.target").replace("%player%", player.getName()));
+                        teleportUtil.setReceivedMessage(plugin.getConfig().getString("messages.commands.tpall.other.target").replace("%player%", player.getName()));
                         teleportUtil.setStaffMessage(plugin.getConfig().getString("messages.commands.tpall.other.staff").replace("%player%", (sender instanceof ConsoleCommandSender ? Utils.getConsoleName() : sender.getName())).replace("%target%", player.getName()));
                         teleportUtil.teleportPlayer();
                     } else {
@@ -47,7 +47,7 @@ public class tpall implements CommandExecutor {
                             teleportUtil.setPitch(args[4]);
                         }
                         teleportUtil.setExecutorMessage(plugin.getConfig().getString("messages.commands.tpall.coords.player"));
-                        teleportUtil.setTargetMessage(plugin.getConfig().getString("messages.commands.tpall.coords.target"));
+                        teleportUtil.setReceivedMessage(plugin.getConfig().getString("messages.commands.tpall.coords.target"));
                         teleportUtil.setStaffMessage(plugin.getConfig().getString("messages.commands.tpall.coords.staff").replace("%player%", sender.getName()));
                         teleportUtil.teleportPlayer();
                     }

--- a/src/main/java/me/lloyd26/teleportnotify/commands/tphere.java
+++ b/src/main/java/me/lloyd26/teleportnotify/commands/tphere.java
@@ -26,9 +26,9 @@ public class tphere implements CommandExecutor {
                 } else if (Bukkit.getOnlinePlayers().contains(Bukkit.getPlayer(args[0]))) {
                     if (args.length == 1) {
                         Player target = Bukkit.getPlayer(args[0]);
-                        TeleportUtil teleportUtil = new TeleportUtil(sender, player, target);
+                        TeleportUtil teleportUtil = new TeleportUtil(sender, target, player);
                         teleportUtil.setExecutorMessage(plugin.getConfig().getString("messages.commands.tphere.player").replaceAll("%target%", target.getName()));
-                        teleportUtil.setTargetMessage(plugin.getConfig().getString("messages.commands.tphere.target").replaceAll("%player%", playerName));
+                        teleportUtil.setPlayerMessage(plugin.getConfig().getString("messages.commands.tphere.target").replaceAll("%player%", playerName));
                         teleportUtil.setStaffMessage(plugin.getConfig().getString("messages.commands.tphere.staff").replaceAll("%player%", playerName).replaceAll("%target%", target.getName()));
                         teleportUtil.teleportPlayer();
                     }

--- a/src/main/java/me/lloyd26/teleportnotify/commands/tphere.java
+++ b/src/main/java/me/lloyd26/teleportnotify/commands/tphere.java
@@ -28,7 +28,7 @@ public class tphere implements CommandExecutor {
                         Player target = Bukkit.getPlayer(args[0]);
                         TeleportUtil teleportUtil = new TeleportUtil(sender, target, player);
                         teleportUtil.setExecutorMessage(plugin.getConfig().getString("messages.commands.tphere.player").replaceAll("%target%", target.getName()));
-                        teleportUtil.setPlayerMessage(plugin.getConfig().getString("messages.commands.tphere.target").replaceAll("%player%", playerName));
+                        teleportUtil.setSentMessage(plugin.getConfig().getString("messages.commands.tphere.target").replaceAll("%player%", playerName));
                         teleportUtil.setStaffMessage(plugin.getConfig().getString("messages.commands.tphere.staff").replaceAll("%player%", playerName).replaceAll("%target%", target.getName()));
                         teleportUtil.teleportPlayer();
                     }

--- a/src/main/java/me/lloyd26/teleportnotify/utils/TeleportUtil.java
+++ b/src/main/java/me/lloyd26/teleportnotify/utils/TeleportUtil.java
@@ -24,8 +24,8 @@ public class TeleportUtil {
     Location location;
     String usage;
     String executorMessage;
-    String playerMessage;
-    String targetMessage;
+    String sentMessage;
+    String receivedMessage;
     String staffMessage;
     Collection<? extends Player> onlinePlayers;
     Player playerToSend;
@@ -97,13 +97,13 @@ public class TeleportUtil {
 
     public void setExecutorMessage(String executorMessage) { this.executorMessage = executorMessage; }
 
-    public String getPlayerMessage() { return playerMessage; }
+    public String getSentMessage() { return sentMessage; }
 
-    public void setPlayerMessage(String playerMessage) { this.playerMessage = playerMessage; }
+    public void setSentMessage(String sentMessage) { this.sentMessage = sentMessage; }
 
-    public String getTargetMessage() { return targetMessage; }
+    public String getReceivedMessage() { return receivedMessage; }
 
-    public void setTargetMessage(String targetMessage) { this.targetMessage = targetMessage; }
+    public void setReceivedMessage(String receivedMessage) { this.receivedMessage = receivedMessage; }
 
     public String getStaffMessage() { return staffMessage; }
 
@@ -197,8 +197,8 @@ public class TeleportUtil {
                         getExecutor().sendMessage(ChatColor.translateAlternateColorCodes('&', getExecutorMessage().replace("%coords%", coords)));
                     if (getExecutor().hasPermission("tpnotify.notify.notify")) {
                         if (getPlayer() != null) {
-                            if (getTargetMessage() != null && getPlayer().hasPermission("tpnotify.notify.receive")) {
-                                getPlayer().sendMessage(ChatColor.translateAlternateColorCodes('&', getTargetMessage().replace("%coords%", coords)));
+                            if (getReceivedMessage() != null && getPlayer().hasPermission("tpnotify.notify.receive")) {
+                                getPlayer().sendMessage(ChatColor.translateAlternateColorCodes('&', getReceivedMessage().replace("%coords%", coords)));
                             }
                         }
                         for (Player p : Bukkit.getOnlinePlayers()) {
@@ -223,14 +223,14 @@ public class TeleportUtil {
                     getExecutor().sendMessage(ChatColor.translateAlternateColorCodes('&', getExecutorMessage()));
                 if (getExecutor().hasPermission("tpnotify.notify.notify")) {
                     if (getPlayer() != null) {
-                        if (getTargetMessage() != null && getPlayer().hasPermission("tpnotify.notify.receive")) {
-                            getPlayer().sendMessage(ChatColor.translateAlternateColorCodes('&', getTargetMessage()));
+                        if (getReceivedMessage() != null && getPlayer().hasPermission("tpnotify.notify.receive")) {
+                            getPlayer().sendMessage(ChatColor.translateAlternateColorCodes('&', getReceivedMessage()));
                         }
                     }
                     for (Player p : Bukkit.getOnlinePlayers()) {
                         if (p.hasPermission("tpnotify.notify.receive")) {
                             if (!p.getName().equals(getExecutor().getName()))
-                                p.sendMessage(ChatColor.translateAlternateColorCodes('&', getTargetMessage()));
+                                p.sendMessage(ChatColor.translateAlternateColorCodes('&', getReceivedMessage()));
                             p.sendMessage(ChatColor.translateAlternateColorCodes('&', getStaffMessage()));
                         }
                     }
@@ -243,11 +243,11 @@ public class TeleportUtil {
                 getPlayerToSend().teleport(getPlayerToReceive().getLocation());
                 if (getExecutorMessage() != null)
                     getExecutor().sendMessage(ChatColor.translateAlternateColorCodes('&', getExecutorMessage()));
-                if (getPlayerMessage() != null && getPlayerToSend().hasPermission("tpnotify.notify.receive"))
-                    getPlayerToSend().sendMessage(ChatColor.translateAlternateColorCodes('&', getPlayerMessage()));
+                if (getSentMessage() != null && getPlayerToSend().hasPermission("tpnotify.notify.receive"))
+                    getPlayerToSend().sendMessage(ChatColor.translateAlternateColorCodes('&', getSentMessage()));
                 if (getExecutor().hasPermission("tpnotify.notify.notify")) {
-                    if (getTargetMessage() != null && getPlayerToReceive().hasPermission("tpnotify.notify.receive")) {
-                        getPlayerToReceive().sendMessage(ChatColor.translateAlternateColorCodes('&', getTargetMessage()));
+                    if (getReceivedMessage() != null && getPlayerToReceive().hasPermission("tpnotify.notify.receive")) {
+                        getPlayerToReceive().sendMessage(ChatColor.translateAlternateColorCodes('&', getReceivedMessage()));
                     }
                 }
                 if (getExecutor().hasPermission("tpnotify.notify.notify")) {


### PR DESCRIPTION
# v1.5.1 Update

This update will fix the bug that causes the `/tphere` command to teleport the player/sender to the target player instead of the other way around.